### PR TITLE
Add onZoomBegin and onZoomEnd props

### DIFF
--- a/src/zoom.tsx
+++ b/src/zoom.tsx
@@ -20,6 +20,8 @@ type Props = {
   minimumZoomScale?: number;
   maximumZoomScale?: number;
   simultaneousGesture?: GestureType;
+  onZoomBegin?: () => void;
+  onZoomEnd?: () => void;
 } & ViewProps;
 
 export function Zoom(props: Props) {
@@ -224,11 +226,13 @@ export function Zoom(props: Props) {
     if (scale.value > 1 && !isZoomed.value) {
       isZoomed.value = true;
       if (zoomListContext) runOnJS(zoomListContext.onZoomBegin)();
+      if (onZoomBegin) runOnJS(onZoomBegin)();
     } else if (scale.value === 1 && isZoomed.value) {
       isZoomed.value = false;
       if (zoomListContext) runOnJS(zoomListContext.onZoomEnd)();
+      if (onZoomEnd) runOnJS(onZoomEnd)();
     }
-  }, [zoomListContext]);
+  }, [zoomListContext, onZoomBegin, onZoomEnd]);
 
   const style = useAnimatedStyle(() => {
     return {


### PR DESCRIPTION
This adds a `onZoomBegin` and `onZoomEnd` props when `isZoomed.value` changes.

This could be useful to disable simultaneous gestures (e.g. fling to close) or to hide certain elements in the UI (e.g. next image button).